### PR TITLE
Optimize module path handling

### DIFF
--- a/integro/calls.js
+++ b/integro/calls.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 const calls = {
     methods: {}
@@ -17,13 +18,14 @@ calls.call = async function (method, params, call, emit) {
 calls.load = async function () {
     let dirList = []
     try {
-        dirList = await fs.promises.readdir(__dirname + '/../modules')
+        dirList = await fs.promises.readdir(path.join(__dirname, '..', 'modules'))
     } catch (e) {}
 
     for (const i in dirList) {
         try {
-            if (fs.existsSync(__dirname + '/../modules/' + dirList[i] + '/methods.js')) {
-                const methods = require('../modules/' + dirList[i] + '/methods')
+            const moduleDir = path.join(__dirname, '..', 'modules', dirList[i])
+            if (fs.existsSync(path.join(moduleDir, 'methods.js'))) {
+                const methods = require(path.join(moduleDir, 'methods.js'))
                 for (const i in methods) {
                     calls.methods[i] = methods[i]
                 }

--- a/integro/events.js
+++ b/integro/events.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 const events = {
     list: {}
@@ -17,13 +18,14 @@ events.load = async function () {
 
     let dirList = []
     try {
-        dirList = await fs.promises.readdir(__dirname + '/../modules')
+        dirList = await fs.promises.readdir(path.join(__dirname, '..', 'modules'))
     } catch (e) {}
 
     for (const i in dirList) {
         try {
-            if (fs.existsSync(__dirname + '/../modules/' + dirList[i] + '/subscriptions.js')) {
-                const subscriptions = require('../modules/' + dirList[i] + '/subscriptions')
+            const moduleDir = path.join(__dirname, '..', 'modules', dirList[i])
+            if (fs.existsSync(path.join(moduleDir, 'subscriptions.js'))) {
+                const subscriptions = require(path.join(moduleDir, 'subscriptions.js'))
                 for (const i in subscriptions) {
                     events.list[i] = events.list[i] || []
                     events.list[i].push(subscriptions[i])


### PR DESCRIPTION
## Summary
- use `path.join` in module loaders for better portability

## Testing
- `npm test` *(fails: no test specified)*
- `node app.js`

------
https://chatgpt.com/codex/tasks/task_e_6845a900e600832f97ca1f9f3ff9626f