### PR TITLE
Convert project to ECMAScript modules

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-const integro = require('./integro')
+import integro from './integro/index.js'
 
 process.on('uncaughtException', function (e) {
     console.error(e)

--- a/integro/calls.js
+++ b/integro/calls.js
@@ -1,5 +1,9 @@
-const fs = require('fs')
-const path = require('path')
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath, pathToFileURL } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const calls = {
     methods: {}
@@ -25,7 +29,8 @@ calls.load = async function () {
         try {
             const moduleDir = path.join(__dirname, '..', 'modules', dirList[i])
             if (fs.existsSync(path.join(moduleDir, 'methods.js'))) {
-                const methods = require(path.join(moduleDir, 'methods.js'))
+                const fileUrl = pathToFileURL(path.join(moduleDir, 'methods.js')).href
+                const methods = (await import(fileUrl)).default
                 for (const i in methods) {
                     calls.methods[i] = methods[i]
                 }
@@ -38,4 +43,4 @@ calls.load = async function () {
     return true
 }
 
-module.exports = calls
+export default calls

--- a/integro/events.js
+++ b/integro/events.js
@@ -1,5 +1,9 @@
-const fs = require('fs')
-const path = require('path')
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath, pathToFileURL } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const events = {
     list: {}
@@ -25,7 +29,8 @@ events.load = async function () {
         try {
             const moduleDir = path.join(__dirname, '..', 'modules', dirList[i])
             if (fs.existsSync(path.join(moduleDir, 'subscriptions.js'))) {
-                const subscriptions = require(path.join(moduleDir, 'subscriptions.js'))
+                const fileUrl = pathToFileURL(path.join(moduleDir, 'subscriptions.js')).href
+                const subscriptions = (await import(fileUrl)).default
                 for (const i in subscriptions) {
                     events.list[i] = events.list[i] || []
                     events.list[i].push(subscriptions[i])
@@ -40,4 +45,4 @@ events.load = async function () {
     
 }
 
-module.exports = events
+export default events

--- a/integro/server.js
+++ b/integro/server.js
@@ -1,8 +1,8 @@
-const express = require('express')
-const bodyParser = require('body-parser')
-const multer = require('multer')
-const http = require('http')
-const path = require('path')
+import express from 'express'
+import bodyParser from 'body-parser'
+import multer from 'multer'
+import http from 'http'
+import path from 'path'
 
 const app = express()
 const forms = multer()
@@ -35,4 +35,4 @@ function server (callback) {
   console.log('server started at ', port)
 }
 
-module.exports = server
+export default server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "integro",
   "version": "0.1.0",
+  "type": "module",
   "description": "Integration Bus Framework",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- enable ESM by setting `type: module`
- migrate sources from `require`/`module.exports` to `import`/`export`
- use dynamic `import()` when reloading modules

## Testing
- `npm test` *(fails: no test specified)*
- `node app.js` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0d92668832f8ff8ae7da8ea62a7