### PR TITLE
Improve docs and bump deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Integro
+
+Integro is a simple integration bus framework built on top of Express. The application dynamically loads modules from the `modules` directory and exposes their HTTP handlers and methods.
+
+## Setup
+
+1. Install Node.js **20**.
+2. Clone the repository and install dependencies:
+   ```bash
+   npm install
+   ```
+3. Copy the example environment file and adjust values if needed:
+   ```bash
+   cp .env.example .env
+   ```
+4. Start the server in development mode:
+   ```bash
+   npm run dev
+   ```
+
+### Environment variables
+
+The application is configured through the following variables defined in `.env`:
+
+| Name          | Description                                                         | Default  |
+|---------------|---------------------------------------------------------------------|----------|
+| `PORT`        | Port where the HTTP server will listen.                             | `4444`   |
+| `UPLOAD_LIMIT`| Maximum request body size accepted by `body-parser`.                | `1024kb` |
+| `VIEW_ENGINE` | Template engine used by Express for rendering views.                | `ejs`    |
+| `RELOAD_TOKEN`| If set, requests containing `reload=<token>` trigger module reload. | —        |
+
+## Module structure
+
+Each module lives inside the `modules/` directory and typically contains the following files:
+
+- `index.js` – HTTP request handler
+- `methods.js` – exported methods that can be called internally
+- `subscriptions.js` – event handlers subscribed to specific events
+- `main.js` – optional file implementing the module logic
+
+Modules are loaded automatically; simply create a new folder under `modules/` containing these files.
+
+## package-lock.json
+
+The `package-lock.json` file is deliberately ignored in `.gitignore` so that every installation resolves the latest compatible versions of dependencies. This project currently does not commit the lockfile.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "integro",
-    "version": "0.1.0",
+    "version": "0.9.0",
     "type": "module",
     "description": "Integration Bus Framework",
     "main": "app.js",
@@ -12,13 +12,16 @@
     "author": "oleksandr_voznyi",
     "license": "GPL-3.0-or-later",
     "dependencies": {
-        "body-parser": "^1.20.0",
+        "body-parser": "^2.2.0",
         "dotenv": "^16.0.1",
         "ejs": "^3.1.8",
-        "express": "^4.18.1",
-        "multer": "^1.4.5-lts.1"
+        "express": "^5.1.0",
+        "multer": "^2.0.1"
     },
     "devDependencies": {
         "nodemon": "^3.1.10"
+    },
+    "engines": {
+        "node": "20"
     }
 }


### PR DESCRIPTION
## Summary
- document setup and module structure in README
- list environment variables and explain ignoring package-lock
- update Express-related dependencies to latest versions
- specify Node.js 20 in engines field
- bump version to 0.9.0

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845c5d1e9e0832fb89fee53adf6fe26