### PR TITLE
Fix crash on startup with Express 5

### DIFF
--- a/integro/server.js
+++ b/integro/server.js
@@ -24,7 +24,7 @@ function server (callback) {
     type: 'application/xml'
   }))
 
-  app.all('*', function (req, res) {
+  app.all('/*splat', function (req, res) {
     callback(req, res)
   })
 


### PR DESCRIPTION
## Summary
- adjust server's catch-all route syntax for Express 5

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68476dfd81c0832f8c7eb6ccd0701424